### PR TITLE
Rename stanford-proxy to simple-api-proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 keys.json
 *.dat
-stanford-proxy
+simple-api-proxy
 bench/results/*
 !bench/results/ANALYSIS.md
 bench/plots/

--- a/bench/bench.sh
+++ b/bench/bench.sh
@@ -24,7 +24,7 @@ fi
 # Verify proxy is reachable
 if ! curl -sf "$PROXY_HOST/health" >/dev/null 2>&1; then
     echo "ERROR: Proxy not responding at $PROXY_HOST/health"
-    echo "Start it with: $PROJECT_DIR/stanford-proxy serve -port 4001"
+    echo "Start it with: $PROJECT_DIR/simple-api-proxy serve -port 4001"
     exit 1
 fi
 

--- a/bench/results/ANALYSIS.md
+++ b/bench/results/ANALYSIS.md
@@ -1,4 +1,4 @@
-# Benchmark Analysis: stanford-proxy
+# Benchmark Analysis: simple-api-proxy
 
 **Date:** 2026-04-06
 **Author:** Generated from automated benchmark suite
@@ -7,7 +7,7 @@
 
 ### System Under Test
 
-The proxy is a Go reverse proxy (`stanford-proxy`, 327 lines, stdlib only) that:
+The proxy is a Go reverse proxy (`simple-api-proxy`, 327 lines, stdlib only) that:
 
 - Accepts requests authenticated with per-user proxy keys (`pk-` prefixed bearer tokens)
 - Validates the key against an in-memory lookup table loaded from `keys.json`
@@ -15,7 +15,7 @@ The proxy is a Go reverse proxy (`stanford-proxy`, 327 lines, stdlib only) that:
 - Forwards requests to `https://aiapi-prod.stanford.edu` via `net/http/httputil.ReverseProxy`
 - Streams SSE responses with `FlushInterval: -1` (immediate flush)
 
-Source: `main.go` (module `stanford-proxy`, go 1.22.2)
+Source: `main.go` (module `simple-api-proxy`, go 1.22.2)
 
 ### Machine
 
@@ -223,10 +223,10 @@ Based on observed data, this proxy instance (on a 2-core VM) can handle:
 ```bash
 # Build the proxy
 cd ~/projects/proxy-server-for-opencode
-go build -o stanford-proxy .
+go build -o simple-api-proxy .
 
 # Start the proxy
-./stanford-proxy serve -port 4001 &
+./simple-api-proxy serve -port 4001 &
 
 # Run the full benchmark suite (installs hey if needed, generates plots)
 cd bench && bash bench.sh

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module stanford-proxy
+module simple-api-proxy
 
 go 1.22.2

--- a/main.go
+++ b/main.go
@@ -111,7 +111,7 @@ func cmdServe(args []string) {
 	fs := flag.NewFlagSet("serve", flag.ExitOnError)
 	port := fs.Int("port", 4000, "listen port")
 	keysPath := fs.String("keys", "keys.json", "path to keys file")
-	apiKeyPath := fs.String("apikey", "~/.config/stanford-ai/key.dat", "path to API key file")
+	apiKeyPath := fs.String("apikey", "~/.config/simple-api-proxy/key.dat", "path to API key file")
 	upstream := fs.String("upstream", "https://aiapi-prod.stanford.edu", "upstream base URL")
 	fs.Parse(args)
 
@@ -191,7 +191,7 @@ func cmdAdd(args []string) {
 	fs.Parse(args)
 
 	if fs.NArg() < 1 {
-		fmt.Fprintln(os.Stderr, "usage: stanford-proxy add <username> [-keys path]")
+		fmt.Fprintln(os.Stderr, "usage: simple-api-proxy add <username> [-keys path]")
 		os.Exit(1)
 	}
 	username := fs.Arg(0)
@@ -224,7 +224,7 @@ func cmdRevoke(args []string) {
 	fs.Parse(args)
 
 	if fs.NArg() < 1 {
-		fmt.Fprintln(os.Stderr, "usage: stanford-proxy revoke <username> [-keys path]")
+		fmt.Fprintln(os.Stderr, "usage: simple-api-proxy revoke <username> [-keys path]")
 		os.Exit(1)
 	}
 	username := fs.Arg(0)
@@ -297,7 +297,7 @@ func authMiddleware(lookup map[string]string, next http.Handler) http.Handler {
 // --- Main ---
 
 func usage() {
-	fmt.Fprintln(os.Stderr, `usage: stanford-proxy <command> [flags]
+	fmt.Fprintln(os.Stderr, `usage: simple-api-proxy <command> [flags]
 
 commands:
   serve    start the proxy server


### PR DESCRIPTION
## Summary
- Rename all `stanford-proxy` references to `simple-api-proxy` across source, config, and docs
- Update Go module name, binary name, usage strings, and default apikey path
- Benchmark analysis references updated

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)