### PR TITLE
Add Dockerfile and Kubernetes manifests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ bench/results/*
 !bench/results/ANALYSIS.md
 bench/plots/
 bench/.venv/
+k8s/secret.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.22-alpine AS build
+WORKDIR /src
+COPY go.mod main.go ./
+RUN CGO_ENABLED=0 go build -o /simple-api-proxy .
+
+FROM alpine:3.20
+RUN apk add --no-cache ca-certificates
+COPY --from=build /simple-api-proxy /usr/local/bin/simple-api-proxy
+EXPOSE 4000
+ENTRYPOINT ["simple-api-proxy"]
+CMD ["serve", "-port", "4000", "-keys", "/etc/config/keys.json", "-apikey", "/etc/secrets/key.dat"]

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: simple-api-proxy-keys
+data:
+  keys.json: |
+    {
+      "users": {
+        "example-user": {
+          "key": "pk-REPLACE_WITH_GENERATED_KEY",
+          "created": "2026-01-01T00:00:00Z"
+        }
+      }
+    }

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple-api-proxy
+  labels:
+    app: simple-api-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: simple-api-proxy
+  template:
+    metadata:
+      labels:
+        app: simple-api-proxy
+    spec:
+      containers:
+        - name: simple-api-proxy
+          image: simple-api-proxy:latest
+          ports:
+            - containerPort: 4000
+          args:
+            - serve
+            - "-port"
+            - "4000"
+            - "-keys"
+            - /etc/config/keys.json
+            - "-apikey"
+            - /etc/secrets/key.dat
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 4000
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 4000
+            initialDelaySeconds: 1
+            periodSeconds: 5
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "50m"
+            limits:
+              memory: "64Mi"
+              cpu: "100m"
+          volumeMounts:
+            - name: apikey
+              mountPath: /etc/secrets
+              readOnly: true
+            - name: keys
+              mountPath: /etc/config
+              readOnly: true
+      volumes:
+        - name: apikey
+          secret:
+            secretName: simple-api-proxy-apikey
+        - name: keys
+          configMap:
+            name: simple-api-proxy-keys

--- a/k8s/secret.yaml.example
+++ b/k8s/secret.yaml.example
@@ -1,0 +1,13 @@
+# Copy this file to secret.yaml and replace the API key value.
+# Do NOT commit secret.yaml to git.
+#
+# To create the key value, base64-encode your API key:
+#   echo -n "sk-YOUR-REAL-KEY" | base64
+#
+apiVersion: v1
+kind: Secret
+metadata:
+  name: simple-api-proxy-apikey
+type: Opaque
+data:
+  key.dat: REPLACE_WITH_BASE64_ENCODED_API_KEY

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: simple-api-proxy
+  labels:
+    app: simple-api-proxy
+spec:
+  type: ClusterIP
+  selector:
+    app: simple-api-proxy
+  ports:
+    - port: 4000
+      targetPort: 4000
+      protocol: TCP


### PR DESCRIPTION
## Summary
- Multi-stage Dockerfile: Go 1.22 build + Alpine 3.20 runtime with CA certs
- k8s Deployment with liveness/readiness probes on `/health` and resource limits (64Mi/100m)
- ClusterIP Service exposing port 4000
- ConfigMap for `keys.json` with example entry
- Secret template (`secret.yaml.example`) for the upstream API key

## Deploy
```bash
cp k8s/secret.yaml.example k8s/secret.yaml  # edit with real key
kubectl apply -f k8s/
```

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)